### PR TITLE
Add check for the last reason thrown.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -21,16 +21,25 @@ if (DEBUG) {
 
 export default function(label, callback) {
   assert('ember-test-friendly-error-handler requires a label', label);
-  if (!DEBUG) { return callback; }
+  if (!DEBUG) {
+    return callback;
+  }
 
+  let lastReason;
   return function(reason) {
+    if (reason === lastReason) {
+      lastReason = null;
+      return;
+    }
+
+    lastReason = reason;
+
     if (squelchedLabels[label]) {
       return callback(reason);
     }
 
-    return resolve(callback(reason))
-      .then(() => {
-        throw reason;
-      });
+    return resolve(callback(reason)).then(() => {
+      throw reason;
+    });
   };
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -27,6 +27,7 @@ export default function(label, callback) {
 
   let lastReason;
   return function(reason) {
+    // avoid reentrance and infinite async loops
     if (reason === lastReason) {
       lastReason = null;
       return;
@@ -34,10 +35,12 @@ export default function(label, callback) {
 
     lastReason = reason;
 
+    // only call the callback when squelched
     if (squelchedLabels[label]) {
       return callback(reason);
     }
 
+    // otherwise call the callback, and rethrow
     return resolve(callback(reason)).then(() => {
       throw reason;
     });

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}


### PR DESCRIPTION
When an unhandled, non-promise error gets thrown, the top-level error handler ends up throwing in a mostly-endless loop: once for the error itself, and then once when rethrown by the promise `.then` on the next cycle of the run loop.

Prevent cycling through these rethrows by tracking the last reason something threw for each label, and if the reason is the same as a previously thrown reason, simply return, and unset the reason so that if the same error is *actually* thrown again later, it won't be swallowed.